### PR TITLE
Update indicatif to 0.18.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/jmgao/progpool"
 license = "Apache-2.0"
 
 [dependencies]
-indicatif = "^0.17.8"
+indicatif = "^0.18.0"
 rayon = "^1.10.0"
 
 tracing = "^0.1.40"


### PR DESCRIPTION
The only breaking change in `indicatif` 0.18 is that the `console` dependency is updated to [0.16.0](https://github.com/console-rs/console/releases/tag/0.16.0); the breaking change in that release is that crates that depend on `console` with `default-features = False` may need to explicitly enable the new `std` feature.